### PR TITLE
Switch OTEL from config to alternateConfig.

### DIFF
--- a/charts/edgenode-observability/deployments/edgenode-observability/values.yaml
+++ b/charts/edgenode-observability/deployments/edgenode-observability/values.yaml
@@ -63,7 +63,7 @@ opentelemetry-collector:
     sidecar.istio.io/proxyCPULimit: 2000m
     sidecar.istio.io/proxyMemory: 32Mi
     sidecar.istio.io/proxyMemoryLimit: 512Mi
-  config:
+  alternateConfig:
     extensions:
       headers_setter:
         headers:

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -218,6 +218,8 @@ opentelemetry-collector-daemonset:
           - node
 
     processors:
+      memory_limiter:
+        limit_percentage: 70
       resource/remove_container_id:
         attributes:
           - action: delete

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -218,6 +218,7 @@ opentelemetry-collector-daemonset:
           - node
 
     processors:
+      batch: {}
       memory_limiter:
         check_interval: 5s
         limit_percentage: 70
@@ -355,6 +356,7 @@ opentelemetry-collector:
           - MemoryPressure
 
     processors:
+      batch: {}
       memory_limiter:
         check_interval: 5s
         limit_percentage: 70
@@ -403,6 +405,14 @@ opentelemetry-collector:
       extensions:
         - health_check
       pipelines:
+        logs:
+          exporters:
+            - debug
+          processors:
+            - memory_limiter
+            - batch
+          receivers:
+            - otlp
         metrics:
           exporters:
             - otlphttp/metrics

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -354,6 +354,14 @@ opentelemetry-collector:
         node_conditions_to_report:
           - Ready
           - MemoryPressure
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: opentelemetry-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets:
+                    - ${env:MY_POD_IP}:8888
 
     processors:
       batch: {}

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -130,7 +130,7 @@ opentelemetry-collector-daemonset:
       enabled: true
     logsCollection:
       enabled: true
-  config:
+  alternateConfig:
     extensions:
       health_check:
         endpoint: "0.0.0.0:13133"
@@ -335,7 +335,7 @@ opentelemetry-collector:
       enabled: true
     kubernetesEvents:
       enabled: true
-  config:
+  alternateConfig:
     extensions:
       health_check:
         endpoint: "0.0.0.0:13133"

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -219,6 +219,7 @@ opentelemetry-collector-daemonset:
 
     processors:
       memory_limiter:
+        check_interval: 5s
         limit_percentage: 70
       resource/remove_container_id:
         attributes:
@@ -355,6 +356,7 @@ opentelemetry-collector:
 
     processors:
       memory_limiter:
+        check_interval: 5s
         limit_percentage: 70
       resource/remove_container_id:
         attributes:

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -436,7 +436,6 @@ opentelemetry-collector:
         traces:
           receivers:
             - otlp
-            - zipkin
             - jaeger
           processors:
             - probabilistic_sampler

--- a/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
+++ b/charts/orchestrator-observability/deployments/orchestrator-observability/values.yaml
@@ -436,7 +436,6 @@ opentelemetry-collector:
         traces:
           receivers:
             - otlp
-            - jaeger
           processors:
             - probabilistic_sampler
           exporters:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: (C) 2025 Intel Corporation
SPDX-License-Identifier: Apache-2.0
-->

### Description

Change opentelemetry collector config to alternate config for avoiding adding default values.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested on local kind deployment with helm from PR.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
