### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/apps/orch-otelcol/o11y-otel-contextprocessor/otelcol-dev/contextprocessor"  # Changed from "directories" to "directory"
     schedule:
@@ -21,6 +23,8 @@ updates:
           - "*"  # In this case, it's good to bump dependencies in one PR, so group all updates into a single larger pull request.
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -28,6 +32,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/apps/grafana-proxy"  # Changed from "directories" to "directory" and split into separate blocks
     schedule:
@@ -35,6 +41,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/apps/orch-otelcol"  # Second docker directory as separate block
     schedule:
@@ -42,3 +50,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to add a cooldown period for several package ecosystems. The cooldown ensures that after a dependency update PR is merged, Dependabot will wait 7 days before creating another PR for the same dependency, reducing noise from frequent updates.

Dependabot configuration improvements:

* Added a `cooldown` section with `default-days: 7` to the `gomod`, `github-actions`, and both `docker` package-ecosystem configurations. This will limit the frequency of update PRs for these ecosystems. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R14-R15) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R26-R54)